### PR TITLE
Enhancement: Add Support for extra settings and set sensible defaults

### DIFF
--- a/master_nodes.tf
+++ b/master_nodes.tf
@@ -78,6 +78,8 @@ resource "proxmox_vm_qemu" "k3s-master" {
 
   sshkeys = file(var.authorized_keys_file)
 
+  nameserver = var.nameserver
+
   connection {
     type = "ssh"
     user = local.master_node_settings.user
@@ -99,6 +101,8 @@ resource "proxmox_vm_qemu" "k3s-master" {
           user     = "k3s"
           password = random_password.k3s-master-db-password.result
         }]
+
+        http_proxy  = var.http_proxy
       })
     ]
   }

--- a/master_nodes.tf
+++ b/master_nodes.tf
@@ -42,6 +42,8 @@ resource "proxmox_vm_qemu" "k3s-master" {
   sockets = local.master_node_settings.sockets
   memory  = local.master_node_settings.memory
 
+  agent = 1
+
   disk {
     type    = local.master_node_settings.storage_type
     storage = local.master_node_settings.storage_id

--- a/master_nodes.tf
+++ b/master_nodes.tf
@@ -61,6 +61,14 @@ resource "proxmox_vm_qemu" "k3s-master" {
     tag       = local.master_node_settings.network_tag
   }
 
+  lifecycle {
+    ignore_changes = [
+      ciuser,
+      sshkeys,
+      disk,
+      network
+    ]
+  }
 
   os_type = "cloud-init"
 

--- a/master_nodes.tf
+++ b/master_nodes.tf
@@ -11,6 +11,7 @@ locals {
     storage_id   = "local-lvm"
     disk_size    = "20G"
     user         = "k3s"
+    network_tag  = -1
   })
 
   master_node_ips = [for i in range(var.master_nodes_count) : cidrhost(var.control_plane_subnet, i + 1)]
@@ -54,7 +55,7 @@ resource "proxmox_vm_qemu" "k3s-master" {
     model     = "virtio"
     queues    = 0
     rate      = 0
-    tag       = -1
+    tag       = local.master_node_settings.network_tag
   }
 
 

--- a/scripts/install-k3s-server.sh.tftpl
+++ b/scripts/install-k3s-server.sh.tftpl
@@ -1,3 +1,8 @@
+HTTP_PROXY="${http_proxy}"
+HTTPS_PROXY="${http_proxy}"
+http_proxy="${http_proxy}"
+https_proxy="${http_proxy}"
+
 curl -sfL https://get.k3s.io | sh -s - ${mode} \
 %{ for component in disable ~}
 --disable ${component} \

--- a/scripts/install-k3s-server.sh.tftpl
+++ b/scripts/install-k3s-server.sh.tftpl
@@ -1,7 +1,7 @@
-HTTP_PROXY="${http_proxy}"
-HTTPS_PROXY="${http_proxy}"
-http_proxy="${http_proxy}"
-https_proxy="${http_proxy}"
+export HTTP_PROXY="${http_proxy}"
+export HTTPS_PROXY="${http_proxy}"
+export http_proxy="${http_proxy}"
+export https_proxy="${http_proxy}"
 
 curl -sfL https://get.k3s.io | sh -s - ${mode} \
 %{ for component in disable ~}

--- a/scripts/install-support-apps.sh.tftpl
+++ b/scripts/install-support-apps.sh.tftpl
@@ -5,13 +5,13 @@ MARIADB_K3S_DATABASE="${k3s_database}"
 MARIADB_K3S_USER="${k3s_user}"
 MARIADB_K3S_PASSWORD="${k3s_password}"
 
-HTTP_PROXY="${http_proxy}"
-HTTPS_PROXY="${http_proxy}"
-http_proxy="${http_proxy}"
-https_proxy="${http_proxy}"
+export HTTP_PROXY="${http_proxy}"
+export HTTPS_PROXY="${http_proxy}"
+export http_proxy="${http_proxy}"
+export https_proxy="${http_proxy}"
 
 mariadb() {
-    sudo apt install mariadb-server -y
+    sudo -E apt install mariadb-server -y
 
     # Make mariadb listen to all remote requests
     sudo sed -i -e 's/\(bind-address\s*=\s*\)[0-9.]*/\10.0.0.0/g' /etc/mysql/mariadb.conf.d/50-server.cnf
@@ -33,7 +33,7 @@ mariadb() {
 }
 
 nginx() {
-    sudo apt install nginx -y
+    sudo -E apt install nginx -y
 }
 
 mariadb

--- a/scripts/install-support-apps.sh.tftpl
+++ b/scripts/install-support-apps.sh.tftpl
@@ -5,6 +5,11 @@ MARIADB_K3S_DATABASE="${k3s_database}"
 MARIADB_K3S_USER="${k3s_user}"
 MARIADB_K3S_PASSWORD="${k3s_password}"
 
+HTTP_PROXY="${http_proxy}"
+HTTPS_PROXY="${http_proxy}"
+http_proxy="${http_proxy}"
+https_proxy="${http_proxy}"
+
 mariadb() {
     sudo apt install mariadb-server -y
 

--- a/support_node.tf
+++ b/support_node.tf
@@ -63,6 +63,14 @@ resource "proxmox_vm_qemu" "k3s-support" {
     tag       = local.support_node_settings.network_tag
   }
 
+  lifecycle {
+    ignore_changes = [
+      ciuser,
+      sshkeys,
+      disk,
+      network
+    ]
+  }
 
   os_type = "cloud-init"
 

--- a/support_node.tf
+++ b/support_node.tf
@@ -14,8 +14,12 @@ locals {
     user         = "support"
     network_tag  = -1
 
+
+
     db_name = "k3s"
     db_user = "k3s"
+
+    
 
     network_bridge = "vmbr0"
   })
@@ -40,6 +44,8 @@ resource "proxmox_vm_qemu" "k3s-support" {
   sockets = local.support_node_settings.sockets
   memory  = local.support_node_settings.memory
 
+
+  agent = 1
   disk {
     type    = local.support_node_settings.storage_type
     storage = local.support_node_settings.storage_id

--- a/support_node.tf
+++ b/support_node.tf
@@ -12,6 +12,7 @@ locals {
     storage_id   = "local-lvm"
     disk_size    = "10G"
     user         = "support"
+    network_tag  = -1
 
     db_name = "k3s"
     db_user = "k3s"
@@ -51,7 +52,7 @@ resource "proxmox_vm_qemu" "k3s-support" {
     model     = "virtio"
     queues    = 0
     rate      = 0
-    tag       = -1
+    tag       = local.support_node_settings.network_tag
   }
 
 

--- a/support_node.tf
+++ b/support_node.tf
@@ -80,6 +80,8 @@ resource "proxmox_vm_qemu" "k3s-support" {
 
   sshkeys = file(var.authorized_keys_file)
 
+  nameserver = var.nameserver
+
   connection {
     type = "ssh"
     user = local.support_node_settings.user
@@ -94,6 +96,8 @@ resource "proxmox_vm_qemu" "k3s-support" {
       k3s_database = local.support_node_settings.db_name
       k3s_user     = local.support_node_settings.db_user
       k3s_password = random_password.k3s-master-db-password.result
+      
+      http_proxy  = var.http_proxy
     })
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,7 @@ variable "support_node_settings" {
     user         = optional(string),
     db_name      = optional(string),
     db_user      = optional(string),
+    network_tag  = optional(number),    
   })
 }
 
@@ -89,6 +90,7 @@ variable "master_node_settings" {
     storage_id   = optional(string),
     disk_size    = optional(string),
     user         = optional(string),
+    network_tag  = optional(number),
   })
 }
 
@@ -109,6 +111,7 @@ variable "node_pools" {
     storage_id   = optional(string),
     disk_size    = optional(string),
     user         = optional(string),
+    network_tag  = optional(number),
 
     template = optional(string),
   }))

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,16 @@ variable "k3s_disable_components" {
   type        = list(string)
   default     = []
 }
+
+
+variable "http_proxy" {
+  default     = ""
+  type        = string
+  description = "http_proxy"
+}
+
+variable "nameserver" {
+  default     = ""
+  type        = string
+  description = "nameserver"
+}

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -16,6 +16,7 @@ locals {
         storage_id   = "local-lvm"
         disk_size    = "20G"
         user         = "k3s"
+        network_tag  = -1
         template     = var.node_template
         }), {
         i  = i
@@ -64,7 +65,7 @@ resource "proxmox_vm_qemu" "k3s-worker" {
     model     = "virtio"
     queues    = 0
     rate      = 0
-    tag       = -1
+    tag       = each.value.network_tag
   }
 
   os_type = "cloud-init"

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -71,6 +71,15 @@ resource "proxmox_vm_qemu" "k3s-worker" {
     tag       = each.value.network_tag
   }
 
+  lifecycle {
+    ignore_changes = [
+      ciuser,
+      sshkeys,
+      disk,
+      network
+    ]
+  }
+
   os_type = "cloud-init"
 
   ciuser = each.value.user

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -88,6 +88,8 @@ resource "proxmox_vm_qemu" "k3s-worker" {
 
   sshkeys = file(var.authorized_keys_file)
 
+  nameserver = var.nameserver
+
   connection {
     type = "ssh"
     user = each.value.user
@@ -104,6 +106,8 @@ resource "proxmox_vm_qemu" "k3s-worker" {
         server_hosts = ["https://${local.support_node_ip}:6443"]
         node_taints  = each.value.taints
         datastores   = []
+
+        http_proxy  = var.http_proxy
       })
     ]
   }

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -52,6 +52,8 @@ resource "proxmox_vm_qemu" "k3s-worker" {
   sockets = each.value.sockets
   memory  = each.value.memory
 
+  agent = 1
+
   disk {
     type    = each.value.storage_type
     storage = each.value.storage_id


### PR DESCRIPTION
- Add Support for Setting name server in cloudinit
- Add Support for http_proxy in install scripts
- Enable Guest Agent leads to fast build and running recondition.  
- Set lifecycle ignore for minor changes in VM state.
_Currently if VM is set to 20G disk may actually be 19880M on disk.  On a rerun the VM would be destroyed and rebuilt!!!_