### PR TITLE
Feature: Ability to specify start vmid for node creation

### DIFF
--- a/master_nodes.tf
+++ b/master_nodes.tf
@@ -32,6 +32,7 @@ resource "proxmox_vm_qemu" "k3s-master" {
   count       = var.master_nodes_count
   target_node = var.proxmox_node
   name        = "${var.cluster_name}-master-${count.index}"
+  vmid        = "${var.start_vmid}" + 5 + tonumber("${count.index}")
 
   clone = var.node_template
 

--- a/support_node.tf
+++ b/support_node.tf
@@ -30,6 +30,7 @@ locals {
 resource "proxmox_vm_qemu" "k3s-support" {
   target_node = var.proxmox_node
   name        = join("-", [var.cluster_name, "support"])
+  vmid        = "${var.start_vmid}"
 
   clone = var.node_template
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "authorized_keys_file" {
   type        = string
 }
 
+variable "start_vmid" {
+  description = "Start vm-id for support node"
+  type        = number
+  default     = "2000"
+}
+
 variable "network_gateway" {
   description = "IP address of the network gateway."
   type        = string

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -42,6 +42,7 @@ resource "proxmox_vm_qemu" "k3s-worker" {
 
   target_node = var.proxmox_node
   name        = "${var.cluster_name}-${each.key}"
+  vmid        = "${var.start_vmid}" + 10 + tonumber("${each.value.i}")
 
   clone = each.value.template
 

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -42,7 +42,6 @@ resource "proxmox_vm_qemu" "k3s-worker" {
 
   target_node = var.proxmox_node
   name        = "${var.cluster_name}-${each.key}"
-  vmid        = "${var.start_vmid}" + 10 + tonumber("${each.value.i}")
 
   clone = each.value.template
 


### PR DESCRIPTION
I found a couple of issues with the existing auto numbering using a free vmid (-1)

Firstly, I tried to create two separate clusters on the same proxmox host and while the first completed successfully, the second cluster started to destroy and overwrite the first cluster, as it used the same vmids.

So I found the -1 for vmid was not working in this instance.

Secondly, I found that if I wanted to keep consecutive vmids for nodes in the same cluster, I was unable to add a third say master node as the first worker node had taken that vmid.

This may appear to be cosmetic, but when the pve has multiple other vm's it all becomes a bit of a mess.

I guess one cluster per pve, might work, but specifying a starting vmid allows you to separate cluster 1 to vmid_start = 4000 and cluster 2 vmid_start = 5000.

This is an updated https://github.com/fvumbaca/terraform-proxmox-k3s/pull/13