### PR TITLE
docs: clarify size of vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A module for spinning up an expandable and flexible K3s server for your HomeLab.
 ## Prerequisites
 
 - A Proxmox node with sufficient capacity for all nodes
-- A cloneable or template VM that supports Cloud-init and is based on Debian
+- A cloneable or template VM with a size that does not exceed the smallest node size (10G currently) that supports Cloud-init and is based on Debian
   (ideally ubuntu server)
 - 2 cidr ranges for master and worker nodes NOT handed out by DHCP (nodes are
   configured with static IPs from these ranges)


### PR DESCRIPTION
If you create a template vm that is above the size that is specified for the nodes, proxmox will error because the provider will try to resize down to the vm size specified which is not supported. Currently the support node size defaults to 10G. Your template should be either less than or equal to that size.