### PR TITLE
Variable for Private key

### DIFF
--- a/master_nodes.tf
+++ b/master_nodes.tf
@@ -84,6 +84,7 @@ resource "proxmox_vm_qemu" "k3s-master" {
     type = "ssh"
     user = local.master_node_settings.user
     host = local.master_node_ips[count.index]
+    private_key = file("${var.private_key}")
   }
 
   provisioner "remote-exec" {

--- a/support_node.tf
+++ b/support_node.tf
@@ -86,6 +86,7 @@ resource "proxmox_vm_qemu" "k3s-support" {
     type = "ssh"
     user = local.support_node_settings.user
     host = local.support_node_ip
+    private_key = file("${var.private_key}")
   }
 
   provisioner "file" {

--- a/support_node.tf
+++ b/support_node.tf
@@ -137,6 +137,7 @@ resource "null_resource" "k3s_nginx_config" {
     type = "ssh"
     user = local.support_node_settings.user
     host = local.support_node_ip
+    private_key = file("${var.private_key}")
   }
 
   provisioner "file" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "authorized_keys_file" {
   type        = string
 }
 
+variable "private_key" {
+  description = "Path to file containing private SSH key for remoting into nodes. The corresponding public key must be found in authorized_keys_file."
+  type        = string
+  default     = "~/.ssh/id_rsa"
+}
+
 variable "network_gateway" {
   description = "IP address of the network gateway."
   type        = string

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -94,6 +94,7 @@ resource "proxmox_vm_qemu" "k3s-worker" {
     type = "ssh"
     user = each.value.user
     host = each.value.ip
+    private_key = file("${var.private_key}")
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
Using this module in an CI/CD environment fails because the private key is missing. 
This change adds a variable for the private key to remoting into the VMs. 
The default value is `~/.ssh/id_rsa`, so this should work as before when this variable is not set