### PR TITLE
Remove dependance on `module_variable_optional_attrs` experiment to support Terraform v1.3+

### DIFF
--- a/master_nodes.tf
+++ b/master_nodes.tf
@@ -3,17 +3,19 @@ resource "macaddress" "k3s-masters" {
 }
 
 locals {
-  master_node_settings = defaults(var.master_node_settings, {
-    cores          = 2
-    sockets        = 1
-    memory         = 4096
-    storage_type   = "scsi"
-    storage_id     = "local-lvm"
-    disk_size      = "20G"
-    user           = "k3s"
-    network_bridge = "vmbr0"
-    network_tag    = -1
-  })
+  master_node_settings = {
+    cores          = coalesce(var.master_node_settings.cores, 2)
+    sockets        = coalesce(var.master_node_settings.sockets, 1)
+    memory         = coalesce(var.master_node_settings.memory, 4096)
+    storage_type   = coalesce(var.master_node_settings.storage_type, "scsi")
+    storage_id     = coalesce(var.master_node_settings.storage_id, "local-lvm")
+    disk_size      = coalesce(var.master_node_settings.disk_size, "20G")
+    user           = coalesce(var.master_node_settings.user, "k3s")
+    network_bridge = coalesce(var.master_node_settings.network_bridge, "vmbr0")
+    network_tag    = coalesce(var.master_node_settings.network_tag, -1)
+
+    template       = var.node_template
+  }
 
   master_node_ips = [for i in range(var.master_nodes_count) : cidrhost(var.control_plane_subnet, i + 1)]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,11 +5,11 @@ output "k3s_db_password" {
 }
 
 output "k3s_db_name" {
-  value = local.support_node_settings.db_name
+  value = var.support_node_settings.db_name
 }
 
 output "k3s_db_user" {
-  value = local.support_node_settings.db_user
+  value = var.support_node_settings.db_user
 }
 
 output "k3s_db_host" {
@@ -26,7 +26,7 @@ output "support_node_ip" {
 }
 
 output "support_node_user" {
-  value = local.support_node_settings.user
+  value = var.support_node_settings.user
 }
 
 output "master_node_ips" {

--- a/support_node.tf
+++ b/support_node.tf
@@ -2,27 +2,27 @@
 resource "macaddress" "k3s-support" {}
 
 locals {
-  support_node_settings = defaults(var.support_node_settings, {
-    cores   = 2
-    sockets = 1
-    memory  = 4096
+  support_node_settings = {
+    cores   = coalesce(var.support_node_settings.cores, 2)
+    sockets = coalesce(var.support_node_settings.sockets, 1)
+    memory  = coalesce(var.support_node_settings.memory, 4096)
 
 
-    storage_type = "scsi"
-    storage_id   = "local-lvm"
-    disk_size    = "10G"
-    user         = "support"
-    network_tag  = -1
+    storage_type = coalesce(var.support_node_settings.storage_type, "scsi")
+    storage_id   = coalesce(var.support_node_settings.storage_id, "local-lvm")
+    disk_size    = coalesce(var.support_node_settings.disk_size, "10G")
+    user         = coalesce(var.support_node_settings.user, "support")
+    network_tag  = coalesce(var.support_node_settings.network_tag, -1)
 
 
 
-    db_name = "k3s"
-    db_user = "k3s"
+    db_name = coalesce(var.support_node_settings.db_name, "k3s")
+    db_user = coalesce(var.support_node_settings.db_user, "k3s")
 
     
 
-    network_bridge = "vmbr0"
-  })
+    network_bridge = coalesce(var.support_node_settings.network_bridge, "vmbr0")
+  }
 
   support_node_ip = cidrhost(var.control_plane_subnet, 0)
 }

--- a/support_node.tf
+++ b/support_node.tf
@@ -2,28 +2,6 @@
 resource "macaddress" "k3s-support" {}
 
 locals {
-  support_node_settings = {
-    cores   = coalesce(var.support_node_settings.cores, 2)
-    sockets = coalesce(var.support_node_settings.sockets, 1)
-    memory  = coalesce(var.support_node_settings.memory, 4096)
-
-
-    storage_type = coalesce(var.support_node_settings.storage_type, "scsi")
-    storage_id   = coalesce(var.support_node_settings.storage_id, "local-lvm")
-    disk_size    = coalesce(var.support_node_settings.disk_size, "10G")
-    user         = coalesce(var.support_node_settings.user, "support")
-    network_tag  = coalesce(var.support_node_settings.network_tag, -1)
-
-
-
-    db_name = coalesce(var.support_node_settings.db_name, "k3s")
-    db_user = coalesce(var.support_node_settings.db_user, "k3s")
-
-    
-
-    network_bridge = coalesce(var.support_node_settings.network_bridge, "vmbr0")
-  }
-
   support_node_ip = cidrhost(var.control_plane_subnet, 0)
 }
 
@@ -40,27 +18,27 @@ resource "proxmox_vm_qemu" "k3s-support" {
   pool = var.proxmox_resource_pool
 
   # cores = 2
-  cores   = local.support_node_settings.cores
-  sockets = local.support_node_settings.sockets
-  memory  = local.support_node_settings.memory
+  cores   = var.support_node_settings.cores
+  sockets = var.support_node_settings.sockets
+  memory  = var.support_node_settings.memory
 
 
   agent = 1
   disk {
-    type    = local.support_node_settings.storage_type
-    storage = local.support_node_settings.storage_id
-    size    = local.support_node_settings.disk_size
+    type    = var.support_node_settings.storage_type
+    storage = var.support_node_settings.storage_id
+    size    = var.support_node_settings.disk_size
   }
 
   network {
-    bridge    = local.support_node_settings.network_bridge
+    bridge    = var.support_node_settings.network_bridge
     firewall  = true
     link_down = false
     macaddr   = upper(macaddress.k3s-support.address)
     model     = "virtio"
     queues    = 0
     rate      = 0
-    tag       = local.support_node_settings.network_tag
+    tag       = var.support_node_settings.network_tag
   }
 
   lifecycle {
@@ -74,7 +52,7 @@ resource "proxmox_vm_qemu" "k3s-support" {
 
   os_type = "cloud-init"
 
-  ciuser = local.support_node_settings.user
+  ciuser = var.support_node_settings.user
 
   ipconfig0 = "ip=${local.support_node_ip}/${local.lan_subnet_cidr_bitnum},gw=${var.network_gateway}"
 
@@ -84,7 +62,7 @@ resource "proxmox_vm_qemu" "k3s-support" {
 
   connection {
     type = "ssh"
-    user = local.support_node_settings.user
+    user = var.support_node_settings.user
     host = local.support_node_ip
   }
 
@@ -93,8 +71,8 @@ resource "proxmox_vm_qemu" "k3s-support" {
     content = templatefile("${path.module}/scripts/install-support-apps.sh.tftpl", {
       root_password = random_password.support-db-password.result
 
-      k3s_database = local.support_node_settings.db_name
-      k3s_user     = local.support_node_settings.db_user
+      k3s_database = var.support_node_settings.db_name
+      k3s_user     = var.support_node_settings.db_user
       k3s_password = random_password.k3s-master-db-password.result
       
       http_proxy  = var.http_proxy
@@ -134,7 +112,7 @@ resource "null_resource" "k3s_nginx_config" {
 
   connection {
     type = "ssh"
-    user = local.support_node_settings.user
+    user = var.support_node_settings.user
     host = local.support_node_ip
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,7 @@ variable "node_pools" {
     user           = optional(string, "k3s"),
     network_bridge = optional(string, "vmbr0"),
     network_tag    = optional(number, -1),
+    template = optional(string)
   }))
 }
 variable "api_hostnames" {

--- a/variables.tf
+++ b/variables.tf
@@ -62,17 +62,17 @@ variable "proxmox_resource_pool" {
 
 variable "support_node_settings" {
   type = object({
-    cores          = optional(number),
-    sockets        = optional(number),
-    memory         = optional(number),
-    storage_type   = optional(string),
-    storage_id     = optional(string),
-    disk_size      = optional(string),
-    user           = optional(string),
-    db_name        = optional(string),
-    db_user        = optional(string),
-    network_bridge = optional(string),
-    network_tag    = optional(number), 
+    cores          = optional(number, 2),
+    sockets        = optional(number, 1),
+    memory         = optional(number, 4096),
+    storage_type   = optional(string, "scsi"),
+    storage_id     = optional(string, "local-lvm"),
+    disk_size      = optional(string, "20G"),
+    user           = optional(string, "k3s"),
+    network_bridge = optional(string, "vmbr0"),
+    network_tag    = optional(number, -1), 
+    db_name        = optional(string, "k3s"),
+    db_user        = optional(string, "k3s"),
   })
 }
 
@@ -84,15 +84,15 @@ variable "master_nodes_count" {
 
 variable "master_node_settings" {
   type = object({
-    cores          = optional(number),
-    sockets        = optional(number),
-    memory         = optional(number),
-    storage_type   = optional(string),
-    storage_id     = optional(string),
-    disk_size      = optional(string),
-    user           = optional(string),
-    network_bridge = optional(string),
-    network_tag    = optional(number),
+    cores          = optional(number, 2),
+    sockets        = optional(number, 1),
+    memory         = optional(number, 4096),
+    storage_type   = optional(string, "scsi"),
+    storage_id     = optional(string, "local-lvm"),
+    disk_size      = optional(string, "20G"),
+    user           = optional(string, "k3s"),
+    network_bridge = optional(string, "vmbr0"),
+    network_tag    = optional(number, -1),
   })
 }
 
@@ -104,20 +104,17 @@ variable "node_pools" {
     size   = number,
     subnet = string,
 
-    taints = optional(list(string)),
+    taints = optional(list(string), []),
 
-    cores        = optional(number),
-    sockets      = optional(number),
-    memory       = optional(number),
-    storage_type = optional(string),
-    storage_id   = optional(string),
-    disk_size    = optional(string),
-    user         = optional(string),
-    network_tag  = optional(number),
-
-    template = optional(string),
-
-    network_bridge = optional(string),
+    cores          = optional(number, 2),
+    sockets        = optional(number, 1),
+    memory         = optional(number, 4096),
+    storage_type   = optional(string, "scsi"),
+    storage_id     = optional(string, "local-lvm"),
+    disk_size      = optional(string, "20G"),
+    user           = optional(string, "k3s"),
+    network_bridge = optional(string, "vmbr0"),
+    network_tag    = optional(number, -1),
   }))
 }
 variable "api_hostnames" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "Telmate/proxmox"
-      version = "2.9.3"
+      version = "2.9.11"
     }
 
     macaddress = {
@@ -10,8 +10,6 @@ terraform {
       version = "0.3.0"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }
 
 locals {

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -11,7 +11,7 @@ locals {
       merge(pool, {
         i        = i
         ip       = cidrhost(pool.subnet, i)
-        template = var.node_template
+        template = coalesce(pool.template, var.node_template)
       })
     ]
   ])

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -8,23 +8,11 @@ locals {
     for pool in var.node_pools :
     [
       for i in range(pool.size) :
-      {
-        cores          = coalesce(pool.cores, 2)
-        sockets        = coalesce(pool.sockets, 1)
-        memory         = coalesce(pool.memory, 4096)
-        storage_type   = coalesce(pool.storage_type, "scsi")
-        storage_id     = coalesce(pool.storage_id, "local-lvm")
-        disk_size      = coalesce(pool.disk_size, "20G")
-        user           = coalesce(pool.user, "k3s")
-        network_bridge = coalesce(pool.network_bridge, "vmbr0")
-        network_tag    = coalesce(pool.network_tag, -1)
-
-        name = pool.name
-        taints = coalesce(pool.taints, [])
+      merge(pool, {
+        i        = i
+        ip       = cidrhost(pool.subnet, i)
         template = var.node_template
-        i  = i
-        ip = cidrhost(pool.subnet, i)
-      }
+      })
     ]
   ])
 
@@ -109,7 +97,7 @@ resource "proxmox_vm_qemu" "k3s-worker" {
         node_taints  = each.value.taints
         datastores   = []
 
-        http_proxy  = var.http_proxy
+        http_proxy = var.http_proxy
       })
     ]
   }

--- a/worker_nodes.tf
+++ b/worker_nodes.tf
@@ -8,21 +8,23 @@ locals {
     for pool in var.node_pools :
     [
       for i in range(pool.size) :
-      merge(defaults(pool, {
-        cores          = 2
-        sockets        = 1
-        memory         = 4096
-        storage_type   = "scsi"
-        storage_id     = "local-lvm"
-        disk_size      = "20G"
-        user           = "k3s"
-        template       = var.node_template
-        network_bridge = "vmbr0"
-        network_tag    = -1
-        }), {
+      {
+        cores          = coalesce(pool.cores, 2)
+        sockets        = coalesce(pool.sockets, 1)
+        memory         = coalesce(pool.memory, 4096)
+        storage_type   = coalesce(pool.storage_type, "scsi")
+        storage_id     = coalesce(pool.storage_id, "local-lvm")
+        disk_size      = coalesce(pool.disk_size, "20G")
+        user           = coalesce(pool.user, "k3s")
+        network_bridge = coalesce(pool.network_bridge, "vmbr0")
+        network_tag    = coalesce(pool.network_tag, -1)
+
+        name = pool.name
+        taints = coalesce(pool.taints, [])
+        template = var.node_template
         i  = i
         ip = cidrhost(pool.subnet, i)
-      })
+      }
     ]
   ])
 


### PR DESCRIPTION
Hi, very cool project, I had little trouble getting it deployed on my home cluster, however in order for the module to run on Terraform v1.3+, I needed to remove the dependence on the [now concluded](https://developer.hashicorp.com/terraform/language/upgrade-guides#concluding-the-optional-attributes-experiment) `module_variable_optional_attrs` experiment.

This PR uses the `optional()` default value parameter instead.